### PR TITLE
support :as option for ActiveAdmin.register

### DIFF
--- a/lib/activeadmin-cancan/authorization.rb
+++ b/lib/activeadmin-cancan/authorization.rb
@@ -26,7 +26,7 @@ ActiveAdmin::DSL.class_eval do
     @config = config
     resource = controller.resource_class
     instance_eval do
-      menu :if => proc{ can?(:manage, resource) }
+      menu :if => proc{ can?(:index, resource) }
     end
   end
 
@@ -36,6 +36,57 @@ ActiveAdmin::DSL.class_eval do
       menu :if => proc{ can?(:manage, resource) }
     end
   end
+end
+
+ActiveAdmin::Views::IndexAsTable::IndexTableFor.class_eval do
+  # Adds links to View, Edit and Delete
+  def default_actions(options = {})
+    options = {
+      :name => ""
+    }.merge(options)
+    column options[:name] do |resource|
+      links = ''.html_safe
+      if controller.action_methods.include?('show') and controller.can?(:show, resource.class)
+        links += link_to I18n.t('active_admin.view'), resource_path(resource), :class => "member_link view_link"
+      end
+      if controller.action_methods.include?('edit') and controller.can?(:edit, resource.class)
+        links += link_to I18n.t('active_admin.edit'), edit_resource_path(resource), :class => "member_link edit_link"
+      end
+      if controller.action_methods.include?('destroy') and controller.can?(:destroy, resource.class)
+        links += link_to I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'), :class => "member_link delete_link"
+      end
+      links
+    end
+  end
+end
+
+ActiveAdmin::Resource::ActionItems.module_eval do
+  private
+    # Adds the default action items to each resource
+    def add_default_action_items
+      # New Link on all actions except :new and :show
+      add_action_item :except => [:new, :show], :if => proc{ can?(:new, controller.resource_class) } do
+        if controller.action_methods.include?('new')
+          link_to(I18n.t('active_admin.new_model', :model => active_admin_config.resource_name), new_resource_path)
+        end
+      end
+
+      # Edit link on show
+      add_action_item :only => :show, :if => proc{ can?(:edit, controller.resource_class) } do
+        if controller.action_methods.include?('edit')
+          link_to(I18n.t('active_admin.edit_model', :model => active_admin_config.resource_name), edit_resource_path(resource))
+        end
+      end
+
+      # Destroy link on show
+      add_action_item :only => :show, :if => proc{ can?(:destroy, controller.resource_class) } do
+        if controller.action_methods.include?("destroy")
+          link_to(I18n.t('active_admin.delete_model', :model => active_admin_config.resource_name),
+            resource_path(resource),
+            :method => :delete, :confirm => I18n.t('active_admin.delete_confirmation'))
+        end
+      end
+    end
 end
 
 CanCan::ControllerResource.class_eval do

--- a/lib/activeadmin-cancan/authorization.rb
+++ b/lib/activeadmin-cancan/authorization.rb
@@ -16,7 +16,7 @@ ActiveAdmin::Namespace.class_eval do
     end
 
     config = old_register(resource_class, options, &block)
-    config.controller.load_and_authorize_resource
+    config.controller.load_and_authorize_resource :class => resource_class
     config
   end
 end

--- a/lib/activeadmin-cancan/authorization.rb
+++ b/lib/activeadmin-cancan/authorization.rb
@@ -16,7 +16,10 @@ ActiveAdmin::Namespace.class_eval do
     end
 
     config = old_register(resource_class, options, &block)
-    config.controller.load_and_authorize_resource :class => resource_class
+    config.controller.load_and_authorize_resource(
+      :class => resource_class,
+      :instance_name => 'cancan_resource' # don't interfere with ActiveAdmin resource
+    )
     config
   end
 end
@@ -89,10 +92,3 @@ ActiveAdmin::Resource::ActionItems.module_eval do
     end
 end
 
-CanCan::ControllerResource.class_eval do
-  def collection_instance=(instance)
-  end
-
-  def resource_instance=(instance)
-  end
-end

--- a/lib/activeadmin-cancan/authorization.rb
+++ b/lib/activeadmin-cancan/authorization.rb
@@ -33,7 +33,7 @@ ActiveAdmin::DSL.class_eval do
   def prepare_menu5
     resource = controller.resource_class
     instance_eval do
-      menu :if => proc{ can?(:manage, resource) }
+      menu :if => proc{ can?(:index, resource) }
     end
   end
 end

--- a/test/activeadmin-cancan_test.rb
+++ b/test/activeadmin-cancan_test.rb
@@ -12,11 +12,11 @@ class ActiveadminCancanTest < ActiveSupport::TestCase
     ActiveAdmin.register Foo
   end
   
-  test "display menu only if user can manage given resource" do
+  test "display menu only if user can see index for given resource" do
     resource = ActiveAdmin.register(Foo)
-    ActiveAdmin::ResourceDSL.any_instance.expects(:can?).with(:manage, Foo).returns(false)
+    ActiveAdmin::ResourceDSL.any_instance.expects(:can?).with(:index, Foo).returns(false)
     assert !resource.namespace.menu.items.first.display_if_block.call
-    ActiveAdmin::ResourceDSL.any_instance.expects(:can?).with(:manage, Foo).returns(true)
+    ActiveAdmin::ResourceDSL.any_instance.expects(:can?).with(:index, Foo).returns(true)
     assert resource.namespace.menu.items.first.display_if_block.call
   end
   


### PR DESCRIPTION
When I have:
`ActiveAdmin.register Profile, as: "User" do`
it should authorize the Profile resource instead of User.
